### PR TITLE
[CopyInsteadOfShareImages] Only apply media.discordapp.net replacement to attachment urls

### DIFF
--- a/CopyInsteadOfShareImages/build.gradle.kts
+++ b/CopyInsteadOfShareImages/build.gradle.kts
@@ -1,2 +1,2 @@
-version = "1.0.6"
+version = "1.0.7"
 description = "Replaces the share button in the image preview with one that copies the image to the clipboard."

--- a/CopyInsteadOfShareImages/src/main/java/com/accelerator/plugins/CopyInsteadOfShareImages.java
+++ b/CopyInsteadOfShareImages/src/main/java/com/accelerator/plugins/CopyInsteadOfShareImages.java
@@ -116,7 +116,7 @@ public class CopyInsteadOfShareImages extends Plugin {
 				//Better one
 				String imageUri = ((AppFragment)callFrame.thisObject).getMostRecentIntent().getStringExtra("INTENT_MEDIA_URL");
 				if (settings.getBool("replaceMediaWithCDN", true))
-					imageUri = imageUri.replace("media.discordapp.net","cdn.discordapp.com");
+					imageUri = imageUri.replace("media.discordapp.net/attachments","cdn.discordapp.com/attachments");
 				
 				//Because I can't make a string final after it's already been created...
 				final String imageUriFinal = new String(imageUri);


### PR DESCRIPTION
For example stickers always use media.discordapp.net and will break when turned into a cdn url.